### PR TITLE
Wave2 griego

### DIFF
--- a/src/app/views/rolodex_view.js
+++ b/src/app/views/rolodex_view.js
@@ -92,11 +92,10 @@ const RolodexView = Backbone.View.extend({
     // right: name of function that insides page view.
     // Submit events are triggered by forms when the
     // submit button is clicked or the enter key pressed
-    // 'submit .new-contact' : 'addContact',
-    // testing // Ideas
-    'click .btn-save' : 'addContact',
+  // 'click .btn-save' : 'addContact', // works but submit> better
+    // will this work if you use class .new-contact?
+    'submit .new-contact' : 'createContact',
 
-    // 'click .btn-save' : 'createContact',
     'click .btn-cancel':'clearInput'
     // added this here, should it be here or in other spot.??
     // 'click .contact-card': 'showDetails'

--- a/src/app/views/rolodex_view.js
+++ b/src/app/views/rolodex_view.js
@@ -92,7 +92,7 @@ const RolodexView = Backbone.View.extend({
     // right: name of function that insides page view.
     // Submit events are triggered by forms when the
     // submit button is clicked or the enter key pressed
-    'submit .new-contact' : 'addContact',
+    // 'submit .new-contact' : 'addContact',
     // testing // Ideas
     'click .btn-save' : 'addContact',
 


### PR DESCRIPTION
Previous code that worked: 
> when the button with the class of **.btn-save** is clicked run the **addContact** function/action.
  ```'click .btn-save' : 'addContact'```

However, on line 63 found in the [Backbone Live code- branch: '**live-code-sequence**'](https://github.com/Ada-C6/backbone-live-code/blob/live-code-sequence/src/app/views/task_list_view.js)

I noticed that submit was used instead of click. ``` 'submit .new-contact'``` I'd previously tried an iteration of this but it didn't work. Realized it was because I was still trying to call the submit action on '.btn-save' instead of focusing on class name of form. As demonstrated from excerpt mentioned above and displayed below. 
```
events: {
    // Submit events are triggered by forms when the
    // submit button is clicked or the enter key pressed
    'submit .new-task': 'addTask',
    'click .clear-button': 'clearInput'
  },
```

